### PR TITLE
Upgrade assembler with CLI and clipboard integration (#1)

### DIFF
--- a/factorisco_assembler/input_encodings/create_data_blueprint.py
+++ b/factorisco_assembler/input_encodings/create_data_blueprint.py
@@ -67,6 +67,7 @@ def create_data_blueprint(outputs, output_file, output_version="v3"):
         outfile.write(updated_blueprint)
     print("Data Blueprint:")
     print(updated_blueprint)
+    return updated_blueprint
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,5 @@ requires-python = ">=3.12"
 dependencies = [
     "pyyaml==6.0.3",
     "sv-ttk==2.6.1",
+    "pyperclip>=1.8.2",
 ]


### PR DESCRIPTION
* Upgrade assembler script with CLI args and clipboard support

- Use `argparse` for better CLI argument handling.
- Integrate `pyperclip` to copy blueprint string to clipboard.
- Provide user feedback upon successful copy.
- Update `create_data_blueprint` and `assemble` to return blueprint string.
- Add `pyperclip` to `pyproject.toml`.

* Upgrade assembler script with CLI args and clipboard support

- Use `argparse` for better CLI argument handling.
- Integrate `pyperclip` to copy blueprint string to clipboard.
- Provide user feedback upon successful copy.
- Update `create_data_blueprint` and `assemble` to return blueprint string.
- Add `pyperclip` to `pyproject.toml`.

---------