### PR TITLE
Use privacy preserving video links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains the code for the Factorio CPU, including an assembler a
 I gave a talk at the 39th Chaos Communication Congress, the recording is here:
 
 - https://media.ccc.de/v/39c3-cpu-entwicklung-in-factorio-vom-d-flip-flop-bis-zum-eigenen-betriebssystem#l=deu (German)
+- https://youtu.be/FLUeSurkMOI (German)
 - https://media.ccc.de/v/39c3-cpu-entwicklung-in-factorio-vom-d-flip-flop-bis-zum-eigenen-betriebssystem#l=eng (English, live-translated)
 
 Few days later, I recorded an English video at home (basically translating my talk), which you can find here:


### PR DESCRIPTION
- Change link to 39C3 talk in DE to point at media.ccc.de.
- Add link to 39C3 talk in EN (live-translated), pointing at media.ccc.de.
- Remove YouTube tracking code from separate EN talk recording.